### PR TITLE
Adding dataset metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ engines such as <a href="https://g.co/datasetsearch">Google Dataset Search</a>.
   </tr>
   <tr>
     <td>name</td>
-    <td itemprop="name">The Quick, Draw! Dataset</td>
+   <td><pre itemprop="name">The Quick, Draw! Dataset</pre></td>
   </tr>
   <tr>
     <td>alternateName</td>
@@ -187,10 +187,10 @@ engines such as <a href="https://g.co/datasetsearch">Google Dataset Search</a>.
   </tr>
   <tr>
     <td>description</td>
-    <td itemprop="description">The Quick Draw Dataset is a collection of 50 million drawings across 345 categories, contributed by players of the game "Quick, Draw!". The drawings were captured as timestamped vectors, tagged with metadata including what the player was asked to draw and in which country the player was located.
+    <td><pre itemprop="description">The Quick Draw Dataset is a collection of 50 million drawings across 345 categories, contributed by players of the game "Quick, Draw!". The drawings were captured as timestamped vectors, tagged with metadata including what the player was asked to draw and in which country the player was located.
 
 Example drawings:
-![preview](https://github.com/googlecreativelab/quickdraw-dataset/blob/master/preview.jpg)</td>
+![preview](https://github.com/googlecreativelab/quickdraw-dataset/blob/master/preview.jpg)</pre></td>
   </tr>
   <tr>
     <td>provider</td>

--- a/README.md
+++ b/README.md
@@ -155,3 +155,84 @@ May 25, 2017: Updated Sketch-RNN QuickDraw dataset, created `.full.npz` compleme
 
 ## License
 This data made available by Google, Inc. under the [Creative Commons Attribution 4.0 International license.](https://creativecommons.org/licenses/by/4.0/)
+
+## Dataset Metadata
+The following table is necessary for this dataset to be indexed by search
+engines such as <a href="https://g.co/datasetsearch">Google Dataset Search</a>.
+<div itemscope itemtype="http://schema.org/Dataset">
+<table>
+  <tr>
+    <th>property</th>
+    <th>value</th>
+  </tr>
+  <tr>
+    <td>name</td>
+    <td itemprop="name">The Quick, Draw! Dataset</td>
+  </tr>
+  <tr>
+    <td>alternateName</td>
+    <td itemprop="alternateName">Quick Draw Dataset</td>
+  </tr>
+  <tr>
+    <td>alternateName</td>
+    <td itemprop="alternateName">quickdraw-dataset</td>
+  </tr>
+  <tr>
+    <td>url</td>
+    <td itemprop="url">https://github.com/googlecreativelab/quickdraw-dataset</td>
+  </tr>
+  <tr>
+    <td>sameAs</td>
+    <td itemprop="sameAs">https://github.com/googlecreativelab/quickdraw-dataset</td>
+  </tr>
+  <tr>
+    <td>description</td>
+    <td itemprop="description">The Quick Draw Dataset is a collection of 50 million drawings across 345 categories, contributed by players of the game "Quick, Draw!". The drawings were captured as timestamped vectors, tagged with metadata including what the player was asked to draw and in which country the player was located.
+
+Example drawings:
+![preview](https://github.com/googlecreativelab/quickdraw-dataset/blob/master/preview.jpg)</td>
+  </tr>
+  <tr>
+    <td>provider</td>
+    <td>
+      <div itemscope itemtype="http://schema.org/Organization" itemprop="provider">
+        <table>
+          <tr>
+            <th>property</th>
+            <th>value</th>
+          </tr>
+          <tr>
+            <td>name</td>
+            <td itemprop="name">Google</td>
+          </tr>
+          <tr>
+            <td>sameAs</td>
+            <td itemprop="sameAs">https://en.wikipedia.org/wiki/Google</td>
+          </tr>
+        </table>
+      </div>
+    </td>
+  </tr>
+  <tr>
+    <td>license</td>
+    <td>
+      <div itemscope itemtype="http://schema.org/CreativeWork" itemprop="license">
+        <table>
+          <tr>
+            <th>property</th>
+            <th>value</th>
+          </tr>
+          <tr>
+            <td>name</td>
+            <td itemprop="name">CC BY 4.0</td>
+          </tr>
+          <tr>
+            <td>url</td>
+            <td itemprop="url">https://creativecommons.org/licenses/by/4.0/</td>
+          </tr>
+        </table>
+      </div>
+    </td>
+  </tr>
+</table>
+</div>

--- a/README.md
+++ b/README.md
@@ -187,7 +187,8 @@ engines such as <a href="https://g.co/datasetsearch">Google Dataset Search</a>.
   </tr>
   <tr>
     <td>description</td>
-    <td><code itemprop="description">The Quick Draw Dataset is a collection of 50 million drawings across 345 categories, contributed by players of the game "Quick, Draw!". The drawings were captured as timestamped vectors, tagged with metadata including what the player was asked to draw and in which country the player was located.
+    <td><code itemprop="description">The Quick Draw Dataset is a collection of 50 million drawings across 345 categories, contributed by players of the game "Quick, Draw!". The drawings were captured as timestamped vectors, tagged with metadata including what the player was asked to draw and in which country the player was located.\n
+\n
 Example drawings:
 ![preview](https://github.com/googlecreativelab/quickdraw-dataset/blob/master/preview.jpg)</code></td>
   </tr>

--- a/README.md
+++ b/README.md
@@ -167,23 +167,23 @@ engines such as <a href="https://g.co/datasetsearch">Google Dataset Search</a>.
   </tr>
   <tr>
     <td>name</td>
-   <td><pre itemprop="name">The Quick, Draw! Dataset</pre></td>
+    <td><code itemprop="name">The Quick, Draw! Dataset</code></td>
   </tr>
   <tr>
     <td>alternateName</td>
-    <td itemprop="alternateName">Quick Draw Dataset</td>
+    <td><code itemprop="alternateName">Quick Draw Dataset</code></td>
   </tr>
   <tr>
     <td>alternateName</td>
-    <td itemprop="alternateName">quickdraw-dataset</td>
+    <td><code itemprop="alternateName">quickdraw-dataset</code></td>
   </tr>
   <tr>
     <td>url</td>
-    <td itemprop="url">https://github.com/googlecreativelab/quickdraw-dataset</td>
+    <td><code itemprop="url">https://github.com/googlecreativelab/quickdraw-dataset</code></td>
   </tr>
   <tr>
     <td>sameAs</td>
-    <td itemprop="sameAs">https://github.com/googlecreativelab/quickdraw-dataset</td>
+    <td><code itemprop="sameAs">https://github.com/googlecreativelab/quickdraw-dataset</code></td>
   </tr>
   <tr>
     <td>description</td>
@@ -202,11 +202,11 @@ Example drawings:
           </tr>
           <tr>
             <td>name</td>
-            <td itemprop="name">Google</td>
+            <td><code itemprop="name">Google</code></td>
           </tr>
           <tr>
             <td>sameAs</td>
-            <td itemprop="sameAs">https://en.wikipedia.org/wiki/Google</td>
+            <td><code itemprop="sameAs">https://en.wikipedia.org/wiki/Google</code></td>
           </tr>
         </table>
       </div>
@@ -223,11 +223,11 @@ Example drawings:
           </tr>
           <tr>
             <td>name</td>
-            <td itemprop="name">CC BY 4.0</td>
+            <td><code itemprop="name">CC BY 4.0</code></td>
           </tr>
           <tr>
             <td>url</td>
-            <td itemprop="url">https://creativecommons.org/licenses/by/4.0/</td>
+            <td><code itemprop="url">https://creativecommons.org/licenses/by/4.0/</code></td>
           </tr>
         </table>
       </div>

--- a/README.md
+++ b/README.md
@@ -188,7 +188,6 @@ engines such as <a href="https://g.co/datasetsearch">Google Dataset Search</a>.
   <tr>
     <td>description</td>
     <td><code itemprop="description">The Quick Draw Dataset is a collection of 50 million drawings across 345 categories, contributed by players of the game "Quick, Draw!". The drawings were captured as timestamped vectors, tagged with metadata including what the player was asked to draw and in which country the player was located.
-
 Example drawings:
 ![preview](https://github.com/googlecreativelab/quickdraw-dataset/blob/master/preview.jpg)</code></td>
   </tr>

--- a/README.md
+++ b/README.md
@@ -187,10 +187,10 @@ engines such as <a href="https://g.co/datasetsearch">Google Dataset Search</a>.
   </tr>
   <tr>
     <td>description</td>
-    <td><pre itemprop="description">The Quick Draw Dataset is a collection of 50 million drawings across 345 categories, contributed by players of the game "Quick, Draw!". The drawings were captured as timestamped vectors, tagged with metadata including what the player was asked to draw and in which country the player was located.
+    <td><code itemprop="description">The Quick Draw Dataset is a collection of 50 million drawings across 345 categories, contributed by players of the game "Quick, Draw!". The drawings were captured as timestamped vectors, tagged with metadata including what the player was asked to draw and in which country the player was located.
 
 Example drawings:
-![preview](https://github.com/googlecreativelab/quickdraw-dataset/blob/master/preview.jpg)</pre></td>
+![preview](https://github.com/googlecreativelab/quickdraw-dataset/blob/master/preview.jpg)</code></td>
   </tr>
   <tr>
     <td>provider</td>


### PR DESCRIPTION
This dataset adds Schema.org/Dataset metadata making this dataset indexable by search engines such as [Google Dataset Search](https://g.co/datasetsearch).

Validation: https://search.google.com/structured-data/testing-tool#url=https%3A%2F%2Fgithub.com%2Fchrisgorgo%2Fquickdraw-dataset%2Fblob%2Fenh%2Fmetadata%2FREADME.md